### PR TITLE
Refine Bergenline Group site messaging

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,314 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Bergenline Group | Urban Real Estate Partners</title>
+    <meta
+      name="description"
+      content="Bergenline Group collaborates with public- and private-sector partners to move complex urban real estate projects from idea to activation."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Work+Sans:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+    <script defer src="script.js"></script>
+  </head>
+  <body>
+    <header class="site-header" id="top">
+      <div class="container header__inner">
+        <a class="brand" href="#top" aria-label="Bergenline Group home">
+          Bergenline<span>Group</span>
+        </a>
+        <nav class="site-nav" data-nav>
+          <button class="nav__close" type="button" data-nav-close aria-label="Close menu">
+            &times;
+          </button>
+          <ul>
+            <li><a href="#about">About</a></li>
+            <li><a href="#services">Services</a></li>
+            <li><a href="#approach">Approach</a></li>
+            <li><a href="#projects">Projects</a></li>
+            <li><a href="#contact">Contact</a></li>
+          </ul>
+        </nav>
+        <button class="nav-toggle" type="button" data-nav-toggle aria-expanded="false">
+          <span class="nav-toggle__line"></span>
+          <span class="nav-toggle__line"></span>
+          <span class="nav-toggle__line"></span>
+          <span class="sr-only">Open navigation</span>
+        </button>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero">
+        <div class="container hero__inner">
+          <div class="hero__copy">
+            <p class="eyebrow">Urban redevelopment partners</p>
+            <h1>We help neighborhoods realize responsible growth.</h1>
+            <p>
+              Bergenline Group guides mission-driven development teams through strategy, entitlements,
+              and activation so projects deliver lasting value for residents and stakeholders alike.
+            </p>
+            <div class="hero__actions">
+              <a class="btn btn--primary" href="#contact">Start a conversation</a>
+              <a class="btn btn--ghost" href="#projects">View recent work</a>
+            </div>
+          </div>
+          <div class="hero__card">
+            <h2>What we deliver</h2>
+            <p>
+              Strategic guidance across every project phase, grounded in careful research, transparent
+              communication, and respect for the communities we serve.
+            </p>
+            <ul>
+              <li><span>Focus</span>Mixed-use, public realm, and adaptive reuse initiatives</li>
+              <li><span>Partners</span>Municipal agencies, impact investors, mission-led operators</li>
+              <li><span>Support</span>End-to-end management from visioning to launch</li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <section class="section" id="about">
+        <div class="container section__inner">
+          <div class="section__header">
+            <p class="eyebrow">Who we are</p>
+            <h2>Built on experience, driven by purpose.</h2>
+          </div>
+          <div class="section__grid section__grid--two">
+            <div class="card card--text">
+              <p>
+                Bergenline Group is an independent development and advisory studio focused on resilient
+                urban projects. We bridge public and private partners to reimagine existing assets,
+                unlock equitable investment, and deliver spaces that reflect the communities around them.
+              </p>
+              <p>
+                From feasibility through activation, our team leans on collaborative planning, rigorous
+                analysis, and thoughtful stewardship to help clients move forward with confidence.
+              </p>
+            </div>
+            <div class="card card--text">
+              <ul class="list-highlight">
+                <li>Urban infill, mixed-use, and public realm assignments</li>
+                <li>Cross-functional team with backgrounds in planning, finance, and placemaking</li>
+                <li>Emphasis on transparent communication and measurable community benefit</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="section section--muted" id="services">
+        <div class="container section__inner">
+          <div class="section__header">
+            <p class="eyebrow">What we do</p>
+            <h2>Integrated services for complex urban projects.</h2>
+            <p>
+              We tailor each engagement to the local context, combining technical expertise with a
+              commitment to meaningful community outcomes.
+            </p>
+          </div>
+          <div class="section__grid section__grid--three">
+            <article class="card card--service">
+              <h3>Development Management</h3>
+              <p>
+                Guide feasibility, entitlements, capital planning, and delivery with a focus on resilient
+                design and inclusive growth.
+              </p>
+              <ul>
+                <li>Site selection & due diligence</li>
+                <li>Entitlement strategy</li>
+                <li>Capital planning</li>
+              </ul>
+            </article>
+            <article class="card card--service">
+              <h3>Public-Private Advisory</h3>
+              <p>
+                Structure partnerships between agencies, developers, and operators that accelerate
+                investment while safeguarding civic goals.
+              </p>
+              <ul>
+                <li>RFP response & positioning</li>
+                <li>Community engagement</li>
+                <li>Public funding alignment</li>
+              </ul>
+            </article>
+            <article class="card card--service">
+              <h3>Place Activation</h3>
+              <p>
+                Curate tenant mix, program experiences, and develop positioning that makes new destinations
+                feel authentic from day one.
+              </p>
+              <ul>
+                <li>Tenant strategy</li>
+                <li>Brand & marketing systems</li>
+                <li>Activation roadmap</li>
+              </ul>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="section" id="approach">
+        <div class="container section__inner">
+          <div class="section__header">
+            <p class="eyebrow">How we work</p>
+            <h2>Partnerships anchored in transparency and trust.</h2>
+          </div>
+          <ol class="timeline">
+            <li>
+              <div class="timeline__marker">01</div>
+              <div class="timeline__content">
+                <h3>Discover</h3>
+                <p>
+                  We immerse ourselves in the fabric of the neighborhood, listening to stakeholders and
+                  aligning on shared goals.
+                </p>
+              </div>
+            </li>
+            <li>
+              <div class="timeline__marker">02</div>
+              <div class="timeline__content">
+                <h3>Design</h3>
+                <p>
+                  Our team synthesizes market data, policy requirements, and community input into a bold but
+                  achievable plan.
+                </p>
+              </div>
+            </li>
+            <li>
+              <div class="timeline__marker">03</div>
+              <div class="timeline__content">
+                <h3>Deliver</h3>
+                <p>
+                  We manage execution with an open-book approach, keeping partners informed and empowered from
+                  groundbreaking to activation.
+                </p>
+              </div>
+            </li>
+          </ol>
+        </div>
+      </section>
+
+      <section class="section section--muted" id="projects">
+        <div class="container section__inner">
+          <div class="section__header">
+            <p class="eyebrow">Recent work</p>
+            <h2>Supporting teams from vision to opening day.</h2>
+          </div>
+          <div class="projects">
+            <article class="project-card">
+              <div class="project-card__badge">Mixed-Use</div>
+              <h3>Transit-oriented districts</h3>
+              <p>
+                Coordinated site planning, financing strategy, and stakeholder outreach for mixed-income
+                developments anchored by community-serving retail.
+              </p>
+              <ul>
+                <li>Adaptive reuse of underutilized properties</li>
+                <li>Collaborative engagement with local leaders</li>
+                <li>Phased implementation roadmaps</li>
+              </ul>
+            </article>
+            <article class="project-card">
+              <div class="project-card__badge">Public Realm</div>
+              <h3>Civic space revitalization</h3>
+              <p>
+                Partnered with municipalities to align capital improvements, programming, and operations
+                for welcoming plazas, promenades, and waterfront corridors.
+              </p>
+              <ul>
+                <li>Programming plans informed by community voices</li>
+                <li>Climate-aware infrastructure strategies</li>
+                <li>Long-term stewardship frameworks</li>
+              </ul>
+            </article>
+            <article class="project-card">
+              <div class="project-card__badge">Hospitality</div>
+              <h3>Experience-driven hospitality</h3>
+              <p>
+                Advised mission-led operators on concept development, tenant alignment, and launch plans
+                for boutique lodging and culinary destinations.
+              </p>
+              <ul>
+                <li>Brand positioning rooted in local context</li>
+                <li>Operator and partner selection support</li>
+                <li>Activation plans that sustain momentum</li>
+              </ul>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="section section--accent">
+        <div class="container section__inner section__inner--cta">
+          <div>
+            <h2>Bring us into the conversation early.</h2>
+            <p>
+              Whether you are shaping a new district or repositioning an existing asset, we help teams
+              identify opportunities, build consensus, and move forward together.
+            </p>
+          </div>
+          <a class="btn btn--light" href="#contact">Schedule a strategy session</a>
+        </div>
+      </section>
+
+      <section class="section" id="contact">
+        <div class="container section__inner section__inner--split">
+          <div class="section__header">
+            <p class="eyebrow">Contact</p>
+            <h2>Let’s collaborate.</h2>
+            <p>Share your project details and a member of our team will follow up promptly.</p>
+          </div>
+          <form class="contact-form" action="https://formspree.io/f/mayvlwvr" method="POST">
+            <label>
+              <span>Name</span>
+              <input type="text" name="name" placeholder="Your name" required />
+            </label>
+            <label>
+              <span>Email</span>
+              <input type="email" name="email" placeholder="you@example.com" required />
+            </label>
+            <label>
+              <span>Organization</span>
+              <input type="text" name="organization" placeholder="Company or agency" />
+            </label>
+            <label>
+              <span>How can we help?</span>
+              <textarea name="message" rows="4" placeholder="Tell us about your project" required></textarea>
+            </label>
+            <button class="btn btn--primary" type="submit">Send message</button>
+            <p class="form-footnote">
+              Prefer email? Reach us directly at
+              <a href="mailto:info@bergenlinegroup.com">info@bergenlinegroup.com</a>.
+            </p>
+          </form>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="container site-footer__inner">
+        <div>
+          <a class="brand brand--footer" href="#top">Bergenline<span>Group</span></a>
+          <p>Independent urban real estate advisors serving public- and private-sector partners.</p>
+        </div>
+        <div class="site-footer__meta">
+          <p>&copy; <span id="year"></span> Bergenline Group. All rights reserved.</p>
+          <ul class="site-footer__links">
+            <li><a href="#services">Services</a></li>
+            <li><a href="#projects">Projects</a></li>
+            <li><a href="#contact">Contact</a></li>
+          </ul>
+        </div>
+      </div>
+    </footer>
+
+    <div class="sr-only" aria-live="polite" id="announcement"></div>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,36 @@
+const navToggle = document.querySelector('[data-nav-toggle]');
+const nav = document.querySelector('[data-nav]');
+const closeBtn = document.querySelector('[data-nav-close]');
+const announcement = document.getElementById('announcement');
+const yearEl = document.getElementById('year');
+
+const setNavState = (isOpen) => {
+  if (!nav) return;
+  nav.setAttribute('aria-hidden', String(!isOpen));
+  document.body.classList.toggle('nav-open', isOpen);
+  navToggle?.setAttribute('aria-expanded', String(isOpen));
+  if (announcement) {
+    announcement.textContent = isOpen ? 'Navigation menu opened' : 'Navigation menu closed';
+  }
+};
+
+navToggle?.addEventListener('click', () => {
+  const isOpen = nav.getAttribute('aria-hidden') === 'true';
+  setNavState(isOpen);
+});
+
+closeBtn?.addEventListener('click', () => setNavState(false));
+
+nav?.querySelectorAll('a').forEach((link) => {
+  link.addEventListener('click', () => setNavState(false));
+});
+
+// Initialize hidden state for mobile nav
+if (nav && !nav.hasAttribute('aria-hidden')) {
+  nav.setAttribute('aria-hidden', 'true');
+}
+
+// Set current year in footer
+if (yearEl) {
+  yearEl.textContent = new Date().getFullYear().toString();
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,593 @@
+:root {
+  --color-background: #f9f9fb;
+  --color-surface: #ffffff;
+  --color-surface-alt: #eef1f7;
+  --color-accent: #214c92;
+  --color-accent-light: #3967b1;
+  --color-accent-muted: rgba(33, 76, 146, 0.12);
+  --color-text: #1d2330;
+  --color-text-secondary: #5a6376;
+  --color-border: rgba(29, 35, 48, 0.08);
+  --max-width: 1140px;
+  --transition: all 0.3s ease;
+  font-size: 62.5%;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Work Sans", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 1.6rem;
+  line-height: 1.6;
+  background: var(--color-background);
+  color: var(--color-text);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+a {
+  color: inherit;
+}
+
+a:hover,
+a:focus-visible {
+  color: var(--color-accent);
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+.container {
+  width: min(100% - 3.2rem, var(--max-width));
+  margin-inline: auto;
+}
+
+header,
+main,
+footer {
+  width: 100%;
+}
+
+.site-header {
+  background: rgba(249, 249, 251, 0.88);
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.6);
+}
+
+.header__inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-block: 1.6rem;
+  position: relative;
+}
+
+.brand {
+  font-weight: 700;
+  font-size: 2.2rem;
+  letter-spacing: 0.04em;
+  text-decoration: none;
+  color: var(--color-text);
+}
+
+.brand span {
+  color: var(--color-accent);
+}
+
+.brand--footer {
+  font-size: 2rem;
+}
+
+.site-nav ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  gap: 2.4rem;
+  align-items: center;
+}
+
+.site-nav a {
+  text-decoration: none;
+  font-weight: 500;
+  color: var(--color-text-secondary);
+  transition: var(--transition);
+}
+
+.site-nav a:hover,
+.site-nav a:focus-visible,
+.site-nav a[aria-current="page"] {
+  color: var(--color-accent);
+}
+
+.nav-toggle {
+  background: none;
+  border: none;
+  padding: 0.8rem;
+  display: none;
+  flex-direction: column;
+  gap: 0.6rem;
+  cursor: pointer;
+}
+
+.nav-toggle__line {
+  width: 2.4rem;
+  height: 0.2rem;
+  background: var(--color-text);
+  border-radius: 999px;
+  transition: var(--transition);
+}
+
+.nav__close {
+  display: none;
+}
+
+.hero {
+  padding-block: 8rem 6rem;
+  background: linear-gradient(135deg, rgba(33, 76, 146, 0.14), rgba(33, 76, 146, 0));
+}
+
+.hero__inner {
+  display: grid;
+  gap: 4rem;
+  align-items: center;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.hero__copy h1 {
+  font-size: clamp(3.2rem, 4vw + 1rem, 5.2rem);
+  line-height: 1.1;
+  margin-bottom: 2.4rem;
+}
+
+.hero__copy p {
+  max-width: 58ch;
+  color: var(--color-text-secondary);
+}
+
+.hero__actions {
+  margin-top: 3.2rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.2rem;
+}
+
+.hero__card {
+  background: var(--color-surface);
+  border-radius: 1.6rem;
+  padding: 3.2rem;
+  box-shadow: 0 2rem 4rem rgba(33, 76, 146, 0.08);
+  display: grid;
+  gap: 1.6rem;
+  border: 1px solid var(--color-border);
+}
+
+.hero__card h2 {
+  margin: 0;
+  font-size: 2.4rem;
+}
+
+.hero__card ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+  font-weight: 500;
+}
+
+.hero__card li span {
+  display: block;
+  font-size: 1.2rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--color-text-secondary);
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.28em;
+  font-size: 1.2rem;
+  color: var(--color-accent);
+  font-weight: 600;
+  margin-bottom: 1.6rem;
+}
+
+.section {
+  padding-block: 8rem;
+}
+
+.section--muted {
+  background: var(--color-surface);
+}
+
+.section--accent {
+  background: var(--color-accent);
+  color: #f5f7fd;
+}
+
+.section__inner {
+  display: grid;
+  gap: 3.6rem;
+}
+
+.section__inner--split {
+  gap: 4.8rem;
+  align-items: start;
+}
+
+.section__inner--cta {
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  align-items: center;
+  gap: 3.2rem;
+}
+
+.section__header h2 {
+  font-size: clamp(2.8rem, 2vw + 1rem, 4rem);
+  margin: 0;
+}
+
+.section__header p {
+  color: var(--color-text-secondary);
+  margin: 0;
+  max-width: 62ch;
+}
+
+.section--accent .section__header p {
+  color: rgba(245, 247, 253, 0.76);
+}
+
+.section__grid {
+  display: grid;
+  gap: 3.2rem;
+}
+
+.section__grid--two {
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.section__grid--three {
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.card {
+  background: var(--color-surface);
+  border-radius: 1.6rem;
+  padding: 3.2rem;
+  box-shadow: 0 1.6rem 3.2rem rgba(12, 22, 44, 0.06);
+  border: 1px solid var(--color-border);
+}
+
+.card--text p:not(:last-child) {
+  margin-bottom: 1.6rem;
+}
+
+.card--service ul {
+  margin: 2.4rem 0 0;
+  padding-left: 1.4rem;
+  color: var(--color-text-secondary);
+}
+
+.card--service li {
+  margin-bottom: 0.8rem;
+}
+
+.list-highlight {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1.6rem;
+}
+
+.list-highlight li {
+  background: var(--color-surface-alt);
+  border-radius: 1.2rem;
+  padding: 1.8rem 2.4rem;
+  border: 1px solid rgba(33, 76, 146, 0.08);
+  color: var(--color-text-secondary);
+}
+
+.list-highlight li::marker {
+  content: none;
+}
+
+.timeline {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 2.4rem;
+}
+
+.timeline li {
+  display: grid;
+  gap: 1.6rem;
+  align-items: start;
+  grid-template-columns: auto 1fr;
+}
+
+.timeline__marker {
+  width: 4.8rem;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  background: var(--color-accent-muted);
+  color: var(--color-accent);
+  font-weight: 600;
+  display: grid;
+  place-items: center;
+  font-size: 1.4rem;
+}
+
+.timeline__content h3 {
+  margin: 0 0 0.8rem;
+  font-size: 2.2rem;
+}
+
+.timeline__content p {
+  margin: 0;
+  color: var(--color-text-secondary);
+}
+
+.projects {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 3.2rem;
+}
+
+.project-card {
+  background: var(--color-surface);
+  border-radius: 1.6rem;
+  padding: 3.2rem;
+  border: 1px solid var(--color-border);
+  display: grid;
+  gap: 1.6rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.project-card__badge {
+  position: absolute;
+  top: 2.4rem;
+  right: -6.4rem;
+  transform: rotate(45deg);
+  background: var(--color-accent);
+  color: #f5f7fd;
+  padding: 0.6rem 6rem;
+  font-size: 1.2rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.project-card ul {
+  margin: 0;
+  padding-left: 1.4rem;
+  color: var(--color-text-secondary);
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.2rem 2.4rem;
+  border-radius: 999px;
+  font-weight: 600;
+  text-decoration: none;
+  transition: var(--transition);
+  border: 2px solid transparent;
+  cursor: pointer;
+}
+
+.btn--primary {
+  background: var(--color-accent);
+  color: #f5f7fd;
+}
+
+.btn--primary:hover,
+.btn--primary:focus-visible {
+  background: var(--color-accent-light);
+}
+
+.btn--ghost {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+  background: transparent;
+}
+
+.btn--ghost:hover,
+.btn--ghost:focus-visible {
+  background: rgba(33, 76, 146, 0.08);
+}
+
+.btn--light {
+  background: #f5f7fd;
+  color: var(--color-accent);
+  border-color: transparent;
+}
+
+.btn--light:hover,
+.btn--light:focus-visible {
+  background: rgba(245, 247, 253, 0.85);
+}
+
+.contact-form {
+  display: grid;
+  gap: 2rem;
+  background: var(--color-surface);
+  border-radius: 1.6rem;
+  padding: 3.2rem;
+  border: 1px solid var(--color-border);
+  box-shadow: 0 1.6rem 3.2rem rgba(12, 22, 44, 0.06);
+}
+
+.contact-form label {
+  display: grid;
+  gap: 0.8rem;
+  font-weight: 500;
+}
+
+.contact-form input,
+.contact-form textarea {
+  font: inherit;
+  padding: 1.2rem 1.6rem;
+  border: 1px solid rgba(29, 35, 48, 0.16);
+  border-radius: 0.8rem;
+  transition: var(--transition);
+}
+
+.contact-form input:focus-visible,
+.contact-form textarea:focus-visible {
+  outline: none;
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 4px rgba(33, 76, 146, 0.18);
+}
+
+.contact-form button {
+  justify-self: start;
+}
+
+.form-footnote {
+  margin: 0;
+  font-size: 1.3rem;
+  color: var(--color-text-secondary);
+}
+
+.site-footer {
+  background: #0f172a;
+  color: rgba(255, 255, 255, 0.88);
+  padding-block: 4.8rem 3.2rem;
+  margin-top: auto;
+}
+
+.site-footer__inner {
+  display: grid;
+  gap: 3.2rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  align-items: start;
+}
+
+.site-footer__meta {
+  display: grid;
+  gap: 1.6rem;
+  justify-items: start;
+}
+
+.site-footer__links {
+  list-style: none;
+  display: flex;
+  gap: 1.6rem;
+  padding: 0;
+  margin: 0;
+}
+
+.site-footer__links a {
+  text-decoration: none;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.site-footer__links a:hover,
+.site-footer__links a:focus-visible {
+  color: #ffffff;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 900px) {
+  .nav-toggle {
+    display: flex;
+  }
+
+  .site-nav {
+    position: fixed;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.9);
+    color: #f5f7fd;
+    padding: 8rem 3.2rem 3.2rem;
+    transform: translateX(100%);
+    transition: transform 0.4s ease;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+  }
+
+  .site-nav ul {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 2.4rem;
+    font-size: 2rem;
+  }
+
+  .site-nav a {
+    color: inherit;
+  }
+
+  .site-nav[aria-hidden="false"] {
+    transform: translateX(0);
+  }
+
+  .nav__close {
+    display: block;
+    align-self: flex-end;
+    font-size: 4rem;
+    background: none;
+    border: none;
+    color: inherit;
+    cursor: pointer;
+    margin-bottom: 4rem;
+  }
+
+  body.nav-open {
+    overflow: hidden;
+  }
+
+  .hero__inner {
+    grid-template-columns: 1fr;
+  }
+
+  .hero__card {
+    order: -1;
+  }
+
+  .section__inner--split {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 600px) {
+  .hero {
+    padding-block: 6.4rem 5.6rem;
+  }
+
+  .section {
+    padding-block: 6rem;
+  }
+
+  .card,
+  .contact-form {
+    padding: 2.4rem;
+  }
+
+  .project-card__badge {
+    top: 2rem;
+    right: -6rem;
+  }
+}


### PR DESCRIPTION
## Summary
- replace speculative project metrics with service-focused descriptions grounded in the firm's positioning
- refresh hero, about, and call-to-action copy to emphasize collaborative, community-minded delivery
- add highlight list styling to support the updated about section layout

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68dc84fccb1083309422a8d4c551543d